### PR TITLE
feat(fase3): middleware de autorização por role e testes (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 *.env.production
 .venv/
 
-# PDF
+# Extensions
 *.pdf
+*.xml
+*.log
 
 # Python
 __pycache__/

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,14 @@
+import logging
+from fastapi import Request, HTTPException, status
 from authlib.integrations.starlette_client import OAuth
 from config import settings
+
+# Configure basic logging for auditing (Phase 4 precursor)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger("auth_audit")
 
 oauth = OAuth()
 
@@ -28,3 +37,56 @@ oauth.register(
         "token_endpoint_auth_method": "client_secret_post",
     },
 )
+
+def require_role(*required_roles: str):
+    """
+    FastAPI dependency that checks if the user in session has at least one of the required roles.
+
+    Args:
+        *required_roles: List of roles allowed to access the resource.
+
+    Returns:
+        dict: The user info if authorized.
+
+    Raises:
+        HTTPException: 401 if unauthenticated, 403 if unauthorized.
+    """
+    def role_checker(request: Request):
+        user = request.session.get("user")
+        client_ip = request.client.host if request.client else "unknown"
+        path = request.url.path
+
+        if not user:
+            logger.warning(f"Access Denied: Unauthenticated attempt to {path} from IP {client_ip}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Sessão expirada ou não autenticada. Por favor, faça login."
+            )
+
+        username = user.get("preferred_username", "unknown_user")
+
+        # Safe extraction of roles with edge case handling
+        realm_access = user.get("realm_access", {})
+        if not isinstance(realm_access, dict):
+            realm_access = {}
+        user_roles = realm_access.get("roles", [])
+
+        if not isinstance(user_roles, list):
+            user_roles = []
+
+        # Check if at least one of the required_roles is in user_roles
+        has_access = any(role in user_roles for role in required_roles)
+
+        if not has_access:
+            logger.error(
+                f"Access Denied: User '{username}' (Roles: {user_roles}) "
+                f"tried to access {path} without required roles: {required_roles}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permissões insuficientes. Requer um dos roles: {list(required_roles)}"
+            )
+
+        logger.info(f"Access Granted: User '{username}' accessed {path}")
+        return user
+    return role_checker

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,10 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends
 from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 from config import settings
-from auth import oauth
+from auth import oauth, require_role
 
 app = FastAPI(title="RetailCorp Portal")
 templates = Jinja2Templates(directory="templates")
@@ -58,3 +58,7 @@ async def dashboard(request: Request):
     if not user:
         return RedirectResponse(url="/login")
     return templates.TemplateResponse("dashboard.html", {"request": request, "user": user})
+
+@app.get("/admin")
+async def admin_panel(user: dict = Depends(require_role("admin"))):
+    return {"message": "Welcome, Administrator", "user": user["preferred_username"]}

--- a/app/test_auth.py
+++ b/app/test_auth.py
@@ -1,0 +1,92 @@
+from fastapi.testclient import TestClient
+from main import app
+from auth import require_role
+from fastapi import Depends, FastAPI, Request
+from unittest.mock import MagicMock
+import pytest
+
+client = TestClient(app)
+
+def test_index():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "app": "RetailCorp Portal"}
+
+def test_admin_no_session():
+    # Should return 401 if no user in session
+    response = client.get("/admin")
+    assert response.status_code == 401
+    assert "Sessão expirada" in response.json()["detail"]
+
+def test_require_role_logic():
+    # Test the role_checker directly with various cases
+    checker = require_role("admin")
+    
+    # Case 1: No user
+    mock_request = MagicMock()
+    mock_request.session = {}
+    mock_request.url.path = "/admin"
+    mock_request.client.host = "127.0.0.1"
+    
+    with pytest.raises(Exception) as excinfo:
+        checker(mock_request)
+    assert excinfo.value.status_code == 401
+    assert "Sessão expirada" in excinfo.value.detail
+    
+    # Case 2: Wrong role
+    mock_request.session = {"user": {
+        "preferred_username": "testuser",
+        "realm_access": {"roles": ["cashier"]}
+    }}
+    with pytest.raises(Exception) as excinfo:
+        checker(mock_request)
+    assert excinfo.value.status_code == 403
+    assert "Permissões insuficientes" in excinfo.value.detail
+    assert "admin" in excinfo.value.detail
+    
+    # Case 3: Correct role
+    mock_request.session = {"user": {
+        "preferred_username": "adminuser",
+        "realm_access": {"roles": ["admin", "default-roles"]}
+    }}
+    user = checker(mock_request)
+    assert user["preferred_username"] == "adminuser"
+
+    # Case 4: Multiple roles allowed
+    checker_multi = require_role("admin", "hr")
+    mock_request.session = {"user": {
+        "preferred_username": "hruser",
+        "realm_access": {"roles": ["hr"]}
+    }}
+    user = checker_multi(mock_request)
+    assert user["preferred_username"] == "hruser"
+
+def test_require_role_edge_cases():
+    checker = require_role("admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/test"
+    mock_request.client.host = "127.0.0.1"
+
+    # Edge Case: realm_access missing
+    mock_request.session = {"user": {"preferred_username": "user1"}}
+    with pytest.raises(Exception) as excinfo:
+        checker(mock_request)
+    assert excinfo.value.status_code == 403
+
+    # Edge Case: roles not a list
+    mock_request.session = {"user": {
+        "preferred_username": "user1",
+        "realm_access": {"roles": "not-a-list"}
+    }}
+    with pytest.raises(Exception) as excinfo:
+        checker(mock_request)
+    assert excinfo.value.status_code == 403
+
+    # Edge Case: realm_access not a dict
+    mock_request.session = {"user": {
+        "preferred_username": "user1",
+        "realm_access": "not-a-dict"
+    }}
+    with pytest.raises(Exception) as excinfo:
+        checker(mock_request)
+    assert excinfo.value.status_code == 403


### PR DESCRIPTION
  Implementação da dependência require_role no FastAPI
  Adição de logging de auditoria para acessos (sucesso e erro)
  Proteção da rota /admin como prova de conceito
  Criação de testes unitários para validar lógica de permissões e edge cases