### PR TITLE
feat(jml): centraliza cliente Keycloak e refatora scripts JML

### DIFF
--- a/jml/client.py
+++ b/jml/client.py
@@ -1,0 +1,82 @@
+import os
+import sys
+from dotenv import load_dotenv
+from keycloak import KeycloakAdmin
+
+# Tenta carregar o .env da raiz do projeto
+# Funciona quer o script seja corrido de /jml/ ou da raiz
+dotenv_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+load_dotenv(dotenv_path=dotenv_path)
+
+class KeycloakClient:
+    """
+    Wrapper para a API Admin do Keycloak.
+    Centraliza a configuração e garante que as variáveis JML têm prioridade.
+    """
+
+    # Roles que exigem MFA obrigatório (TOTP)
+    MFA_REQUIRED_ROLES = ["admin", "hr", "store_manager"]
+    
+    def __init__(self):
+        # Prioridade para variáveis JML_*, fallback para as gerais
+        self.server_url = os.getenv("JML_KEYCLOAK_URL", os.getenv("KEYCLOAK_PUBLIC_URL", "http://localhost:8080"))
+        self.username = os.getenv("JML_ADMIN_USER", os.getenv("KEYCLOAK_ADMIN"))
+        self.password = os.getenv("JML_ADMIN_PASSWORD", os.getenv("KEYCLOAK_ADMIN_PASSWORD"))
+        self.realm_name = os.getenv("JML_REALM", os.getenv("KEYCLOAK_REALM", "retailcorp"))
+
+        self._validate_config()
+        self._admin = None
+
+    def _validate_config(self):
+        missing = []
+        if not self.server_url: missing.append("JML_KEYCLOAK_URL")
+        if not self.username: missing.append("JML_ADMIN_USER")
+        if not self.password: missing.append("JML_ADMIN_PASSWORD")
+        
+        if missing:
+            print(f"[ERROR] Variáveis de ambiente em falta no .env: {', '.join(missing)}")
+            sys.exit(1)
+
+    @property
+    def admin(self) -> KeycloakAdmin:
+        """Retorna a instância do KeycloakAdmin (lazy loading)."""
+        if self._admin is None:
+            try:
+                self._admin = KeycloakAdmin(
+                    server_url=self.server_url,
+                    username=self.username,
+                    password=self.password,
+                    realm_name=self.realm_name,
+                    user_realm_name="master",
+                    verify=True
+                )
+            except Exception as e:
+                print(f"[ERROR] Não foi possível ligar à API Admin do Keycloak: {e}")
+                sys.exit(1)
+        return self._admin
+
+    def get_user_id(self, username: str) -> str:
+        """Resolve username para ID e sai com erro se não encontrar."""
+        user_id = self.admin.get_user_id(username)
+        if not user_id:
+            print(f"[ERROR] Utilizador '{username}' não encontrado no Keycloak.")
+            sys.exit(1)
+        return user_id
+
+    def get_role(self, role_name: str, required: bool = True):
+        """Obtém a representação do role e valida se existe."""
+        try:
+            return self.admin.get_realm_role(role_name)
+        except Exception:
+            if required:
+                print(f"[ERROR] Role '{role_name}' não encontrado no Keycloak.")
+                sys.exit(1)
+            return None
+
+def get_admin_client():
+    """Função utilitária para os scripts JML."""
+    return KeycloakClient().admin
+
+def get_client():
+    """Retorna a instância do wrapper KeycloakClient."""
+    return KeycloakClient()

--- a/jml/joiner.py
+++ b/jml/joiner.py
@@ -1,22 +1,7 @@
-import os
 import argparse
 import sys
-from dotenv import load_dotenv
-from keycloak import KeycloakAdmin, KeycloakPostError
-
-# Carregar variáveis de ambiente da raiz do projeto
-load_dotenv(dotenv_path="../.env")
-
-def get_admin_client():
-    """Configura a ligação à API Admin do Keycloak."""
-    return KeycloakAdmin(
-        server_url=os.getenv("KEYCLOAK_INTERNAL_URL"),
-        username=os.getenv("KEYCLOAK_ADMIN_USER"),
-        password=os.getenv("KEYCLOAK_ADMIN_PASSWORD"),
-        realm_name=os.getenv("KEYCLOAK_REALM"),
-        user_realm_name="master",  # Admin autentica no realm master
-        verify=True
-    )
+from keycloak import KeycloakPostError
+from client import get_client
 
 def main():
     parser = argparse.ArgumentParser(description="RetailCorp JML: Joiner - Criar novo utilizador")
@@ -31,7 +16,8 @@ def main():
 
     args = parser.parse_args()
 
-    keycloak_admin = get_admin_client()
+    client = get_client()
+    keycloak_admin = client.admin
 
     print(f"[*] A criar utilizador '{args.username}'...")
 
@@ -52,14 +38,13 @@ def main():
         keycloak_admin.set_user_password(user_id, args.temp_pass, temporary=True)
         print(f"[+] Password temporária definida: {args.temp_pass}")
 
-        # 3. Atribuir Role
-        role_data = keycloak_admin.get_realm_role(args.role)
+        # 3. Atribuir Role (centralizado no client)
+        role_data = client.get_role(args.role)
         keycloak_admin.assign_realm_roles(user_id, [role_data])
         print(f"[+] Role '{args.role}' atribuído com sucesso.")
 
         # 4. Configurar MFA (TOTP) se o role for sensível
-        sensitive_roles = ["admin", "hr", "store_manager"]
-        if args.role in sensitive_roles:
+        if args.role in client.MFA_REQUIRED_ROLES:
             keycloak_admin.update_user(user_id, {
                 "requiredActions": ["CONFIGURE_TOTP", "UPDATE_PASSWORD"]
             })

--- a/jml/leaver.py
+++ b/jml/leaver.py
@@ -1,21 +1,6 @@
-import os
 import argparse
 import sys
-from dotenv import load_dotenv
-from keycloak import KeycloakAdmin
-
-# Carregar variáveis de ambiente
-load_dotenv(dotenv_path="../.env")
-
-def get_admin_client():
-    return KeycloakAdmin(
-        server_url=os.getenv("KEYCLOAK_INTERNAL_URL"),
-        username=os.getenv("KEYCLOAK_ADMIN_USER"),
-        password=os.getenv("KEYCLOAK_ADMIN_PASSWORD"),
-        realm_name=os.getenv("KEYCLOAK_REALM"),
-        user_realm_name="master",
-        verify=True
-    )
+from client import get_client
 
 def main():
     parser = argparse.ArgumentParser(description="RetailCorp JML: Leaver - Desativar colaborador")
@@ -28,14 +13,12 @@ def main():
         print(f"[!] Aviso: Para desativar '{args.username}', use a flag --confirm.")
         sys.exit(0)
 
-    keycloak_admin = get_admin_client()
+    client = get_client()
+    keycloak_admin = client.admin
 
     try:
-        # 1. Obter ID do utilizador
-        user_id = keycloak_admin.get_user_id(args.username)
-        if not user_id:
-            print(f"[ERROR] Utilizador '{args.username}' não encontrado.")
-            sys.exit(1)
+        # 1. Obter ID do utilizador (centralizado no client)
+        user_id = client.get_user_id(args.username)
 
         print(f"[*] A processar 'Leaver' para '{args.username}'...")
 

--- a/jml/mover.py
+++ b/jml/mover.py
@@ -1,21 +1,6 @@
-import os
 import argparse
 import sys
-from dotenv import load_dotenv
-from keycloak import KeycloakAdmin, KeycloakGetError
-
-# Carregar variáveis de ambiente
-load_dotenv(dotenv_path="../.env")
-
-def get_admin_client():
-    return KeycloakAdmin(
-        server_url=os.getenv("KEYCLOAK_INTERNAL_URL"),
-        username=os.getenv("KEYCLOAK_ADMIN_USER"),
-        password=os.getenv("KEYCLOAK_ADMIN_PASSWORD"),
-        realm_name=os.getenv("KEYCLOAK_REALM"),
-        user_realm_name="master",
-        verify=True
-    )
+from client import get_client
 
 def main():
     parser = argparse.ArgumentParser(description="RetailCorp JML: Mover - Alterar role e revogar sessões")
@@ -26,27 +11,28 @@ def main():
                         help="Novo role a atribuir")
 
     args = parser.parse_args()
-    keycloak_admin = get_admin_client()
+    client = get_client()
+    keycloak_admin = client.admin
 
     try:
-        # 1. Obter ID do utilizador
-        user_id = keycloak_admin.get_user_id(args.username)
-        if not user_id:
-            print(f"[ERROR] Utilizador '{args.username}' não encontrado.")
-            sys.exit(1)
+        # 1. Obter ID do utilizador (centralizado no client)
+        user_id = client.get_user_id(args.username)
 
         print(f"[*] A processar 'Mover' para '{args.username}'...")
 
         # 2. Remover Role antigo
-        try:
-            old_role_data = keycloak_admin.get_realm_role(args.from_role)
-            keycloak_admin.delete_realm_roles_from_user(user_id, [old_role_data])
-            print(f"[+] Role antigo '{args.from_role}' removido.")
-        except Exception:
-            print(f"[!] Aviso: Role '{args.from_role}' não estava atribuído ou não existe.")
+        old_role_data = client.get_role(args.from_role, required=False)
+        if old_role_data:
+            try:
+                keycloak_admin.delete_realm_roles_from_user(user_id, [old_role_data])
+                print(f"[+] Role antigo '{args.from_role}' removido.")
+            except Exception:
+                print(f"[!] Aviso: Role '{args.from_role}' não estava atribuído.")
+        else:
+            print(f"[!] Aviso: Role antigo '{args.from_role}' não existe no Keycloak. A ignorar remoção.")
 
         # 3. Atribuir Novo Role
-        new_role_data = keycloak_admin.get_realm_role(args.to_role)
+        new_role_data = client.get_role(args.to_role, required=True)
         keycloak_admin.assign_realm_roles(user_id, [new_role_data])
         print(f"[+] Novo role '{args.to_role}' atribuído.")
 
@@ -56,8 +42,7 @@ def main():
         print("[+] Sessões ativas revogadas. O utilizador terá de fazer login novamente.")
 
         # 5. Se o novo role exigir MFA e o user não tiver, forçar configuração
-        sensitive_roles = ["admin", "hr", "store_manager"]
-        if args.to_role in sensitive_roles:
+        if args.to_role in client.MFA_REQUIRED_ROLES:
             keycloak_admin.update_user(user_id, {
                 "requiredActions": ["CONFIGURE_TOTP"]
             })


### PR DESCRIPTION
Criação do módulo jml/client.py para centralizar a lógica de autenticação e comunicação com a API Admin do  Keycloak.
 Refatoração dos scripts joiner.py, leaver.py e mover.py para utilizar o novo cliente centralizado, removendo  código duplicado.
 Implementação de suporte a variáveis de ambiente específicas (JML_*) com fallback para as globais.
 Centralização da gestão de roles sensíveis e lógica de validação de utilizadores/roles.
 Melhoria no tratamento de erros e na robustez do carregamento do ficheiro .env.